### PR TITLE
feat: make booking progress bar clickable (#41)

### DIFF
--- a/src/application/app/booking/page.tsx
+++ b/src/application/app/booking/page.tsx
@@ -9,21 +9,28 @@ import { StepDateTime } from "@/components/booking/step-date-time";
 import { StepDetails } from "@/components/booking/step-details";
 import { StepPayment } from "@/components/booking/step-payment";
 import { StepSummary } from "@/components/booking/step-summary";
-import { BookingData, BookingStep, INITIAL_BOOKING_DATA } from "@/components/booking/types";
+import {
+  BookingData,
+  BookingStep,
+  INITIAL_BOOKING_DATA,
+} from "@/components/booking/types";
 
 // Inner component that can safely use useSearchParams
 function BookingPageInner() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const [currentStep, setCurrentStep] = useState<BookingStep>(1);
-  const [bookingData, setBookingData] = useState<BookingData>(INITIAL_BOOKING_DATA);
+  const [bookingData, setBookingData] =
+    useState<BookingData>(INITIAL_BOOKING_DATA);
   const [isAuthenticating, setIsAuthenticating] = useState(true);
 
   // Check authentication
   useEffect(() => {
     const checkAuth = async () => {
       const supabase = createClient();
-      const { data: { session } } = await supabase.auth.getSession();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
 
       if (!session) {
         // Redirect to login via full page load or push depending on preference; push is fine here.
@@ -32,17 +39,20 @@ function BookingPageInner() {
       } else {
         // Fetch user data from database and pre-fill step 3
         try {
-          const res = await fetch(`/api/customer?profile_id=${session.user.id}`);
+          const res = await fetch(
+            `/api/customer?profile_id=${session.user.id}`,
+          );
           if (res.ok) {
             const { data } = await res.json();
             if (data && data.length > 0) {
               const customer = data[0];
-              setBookingData(prev => ({
+              setBookingData((prev) => ({
                 ...prev,
                 firstName: customer.first_name || prev.firstName,
                 lastName: customer.last_name || prev.lastName,
                 phone: customer.phone_number || prev.phone,
-                email: session.user.email || customer.email_address || prev.email,
+                email:
+                  session.user.email || customer.email_address || prev.email,
               }));
             }
           }
@@ -67,14 +77,16 @@ function BookingPageInner() {
         if (!json.success || !json.data) return;
 
         const massage = json.data;
-        setBookingData(prev => ({
+        setBookingData((prev) => ({
           ...prev,
-          selectedServices: [{
-            massage_id: massage.massage_id, // keep as-is (number) to match StepServiceSelection's runtime type
-            massage_name: massage.massage_name,
-            massage_price: massage.massage_price,
-            duration: massage.massage_time ?? 60,
-          }],
+          selectedServices: [
+            {
+              massage_id: massage.massage_id, // keep as-is (number) to match StepServiceSelection's runtime type
+              massage_name: massage.massage_name,
+              massage_price: massage.massage_price,
+              duration: massage.massage_time ?? 60,
+            },
+          ],
         }));
       } catch {
         // Silently ignore — user can manually select
@@ -84,21 +96,59 @@ function BookingPageInner() {
   }, [searchParams]);
 
   const updateData = (updates: Partial<BookingData>) => {
-    setBookingData(prev => ({ ...prev, ...updates }));
+    setBookingData((prev) => ({ ...prev, ...updates }));
   };
 
   const goNext = () => {
-    setCurrentStep(prev => Math.min(prev + 1, 5) as BookingStep);
+    setCurrentStep((prev) => Math.min(prev + 1, 5) as BookingStep);
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   const goBack = () => {
-    setCurrentStep(prev => Math.max(prev - 1, 1) as BookingStep);
+    setCurrentStep((prev) => Math.max(prev - 1, 1) as BookingStep);
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
+  const goToStep = (step: BookingStep) => {
+    setCurrentStep(step);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const canGoToStep = (targetStep: BookingStep) => {
+    if (targetStep === 5) return currentStep === 5; // Can only view step 5 if already there (completed)
+    if (targetStep === 1) return true; // Always able to go to step 1
+
+    // To go to step 2 (or beyond), must have selected at least one service
+    if (bookingData.selectedServices.length === 0) return false;
+    if (targetStep === 2) return true;
+
+    // To go to step 3 (or beyond), must have selected a date and time
+    if (!bookingData.selectedDate || !bookingData.selectedTime) return false;
+    if (targetStep === 3) return true;
+
+    // To go to step 4, must have completed basic user details
+    const isPhoneValid = /^[0-9]{9,10}$/.test(
+      bookingData.phone.replace(/[-\s]/g, ""),
+    );
+    if (
+      !bookingData.firstName.trim() ||
+      !bookingData.lastName.trim() ||
+      !isPhoneValid
+    )
+      return false;
+    if (targetStep === 4) return true;
+
+    return false;
+  };
+
   const serviceId = searchParams.get("serviceId");
-  const stepProps = { data: bookingData, onUpdate: updateData, onNext: goNext, onBack: goBack, autoOpenPicker: !serviceId };
+  const stepProps = {
+    data: bookingData,
+    onUpdate: updateData,
+    onNext: goNext,
+    onBack: goBack,
+    autoOpenPicker: !serviceId,
+  };
 
   if (isAuthenticating) {
     return (
@@ -129,7 +179,11 @@ function BookingPageInner() {
 
         {/* Step progress */}
         <div className="print:hidden">
-          <BookingProgress currentStep={currentStep} />
+          <BookingProgress
+            currentStep={currentStep}
+            onStepClick={goToStep}
+            canGoToStep={canGoToStep}
+          />
         </div>
 
         {/* Divider */}

--- a/src/application/components/booking/booking-progress.tsx
+++ b/src/application/components/booking/booking-progress.tsx
@@ -6,9 +6,15 @@ import { STEPS, BookingStep } from "./types";
 
 interface BookingProgressProps {
   currentStep: BookingStep;
+  onStepClick?: (step: BookingStep) => void;
+  canGoToStep?: (step: BookingStep) => boolean;
 }
 
-export function BookingProgress({ currentStep }: BookingProgressProps) {
+export function BookingProgress({
+  currentStep,
+  onStepClick,
+  canGoToStep,
+}: BookingProgressProps) {
   return (
     <div className="w-full max-w-3xl mx-auto px-4 py-8">
       <div className="relative flex items-start justify-between">
@@ -17,7 +23,7 @@ export function BookingProgress({ currentStep }: BookingProgressProps) {
           className="absolute top-5 h-[2px] bg-border -translate-y-1/2 z-0"
           style={{
             left: `${100 / (2 * STEPS.length)}%`,
-            right: `${100 / (2 * STEPS.length)}%`
+            right: `${100 / (2 * STEPS.length)}%`,
           }}
         />
         {/* Progress fill line */}
@@ -25,7 +31,7 @@ export function BookingProgress({ currentStep }: BookingProgressProps) {
           className="absolute top-5 h-[2px] bg-primary transition-all duration-700 ease-out -translate-y-1/2 z-0"
           style={{
             left: `${100 / (2 * STEPS.length)}%`,
-            width: `calc(${((currentStep - 1) / (STEPS.length - 1)) * 100}% - ${((currentStep - 1) / (STEPS.length - 1)) * (100 / STEPS.length)}%)`
+            width: `calc(${((currentStep - 1) / (STEPS.length - 1)) * 100}% - ${((currentStep - 1) / (STEPS.length - 1)) * (100 / STEPS.length)}%)`,
           }}
         />
 
@@ -42,15 +48,40 @@ export function BookingProgress({ currentStep }: BookingProgressProps) {
               style={{ width: `${100 / STEPS.length}%` }}
             >
               {/* Circle */}
-              <div
+              <button
+                type="button"
+                onClick={() => {
+                  if (
+                    onStepClick &&
+                    canGoToStep &&
+                    canGoToStep(step.id as BookingStep) &&
+                    !isActive
+                  ) {
+                    onStepClick(step.id as BookingStep);
+                  }
+                }}
+                disabled={
+                  !(
+                    onStepClick &&
+                    canGoToStep &&
+                    canGoToStep(step.id as BookingStep) &&
+                    !isActive
+                  )
+                }
                 className={cn(
-                  "h-10 w-10 rounded-full flex items-center justify-center text-sm font-semibold transition-all duration-500 border-2 font-mitr",
-                  isCompleted && 
+                  "h-10 w-10 rounded-full flex items-center justify-center text-sm font-semibold transition-all duration-500 border-2 font-mitr outline-none",
+                  isCompleted &&
                     "bg-primary border-primary text-primary-foreground shadow-md shadow-primary/20",
-                  isActive && 
+                  isActive &&
                     "bg-background border-primary text-primary scale-110 shadow-lg shadow-primary/20 ring-4 ring-primary/10",
-                  isUpcoming && 
-                    "bg-background border-border text-muted-foreground"
+                  isUpcoming &&
+                    "bg-background border-border text-muted-foreground",
+                  onStepClick &&
+                    canGoToStep &&
+                    canGoToStep(step.id as BookingStep) &&
+                    !isActive
+                    ? "cursor-pointer hover:scale-110 hover:shadow-md active:scale-95"
+                    : "cursor-default",
                 )}
               >
                 {isCompleted ? (
@@ -58,7 +89,7 @@ export function BookingProgress({ currentStep }: BookingProgressProps) {
                 ) : (
                   <span>{step.id}</span>
                 )}
-              </div>
+              </button>
 
               {/* Label */}
               <span
@@ -66,7 +97,7 @@ export function BookingProgress({ currentStep }: BookingProgressProps) {
                   "text-xs font-medium text-center leading-tight transition-colors duration-300 font-sans",
                   isActive && "text-primary font-semibold",
                   isCompleted && "text-primary/70",
-                  isUpcoming && "text-muted-foreground"
+                  isUpcoming && "text-muted-foreground",
                 )}
               >
                 {step.label}


### PR DESCRIPTION
Closes #41. Makes the booking progress bar clickable so users can navigate between completed/allowed steps without having to use the next/back buttons repeatedly.