### PR TITLE
fix: only auto-open service picker when no services are selected (resolves #43)

### DIFF
--- a/src/application/components/booking/step-service-selection.tsx
+++ b/src/application/components/booking/step-service-selection.tsx
@@ -434,7 +434,9 @@ export function StepServiceSelection({ data, onUpdate, onNext, autoOpenPicker = 
           duration: SERVICE_META[s.massage_name]?.duration ?? (s.duration ?? DEFAULT_DURATION),
         }));
         setAllServices(enriched);
-        if (autoOpenPicker) setPickerOpen(true);
+        if (autoOpenPicker && data.selectedServices.length === 0) {
+          setPickerOpen(true);
+        }
       } catch (err: unknown) {
         setError(err instanceof Error ? err.message : "เกิดข้อผิดพลาด");
       } finally {


### PR DESCRIPTION
### Description
This PR addresses issue #43 by preventing the service selection modal from automatically popping up when navigating back to step 1 from later steps in the booking process, provided that services have already been selected.

### Changes
- Added a check in `StepServiceSelection` to verify that `data.selectedServices.length === 0` before opening the picker automatically.
- Ensures the modal only auto-opens on the first visit to Step 1.

Resolves #43.