### PR TITLE
fix: update Supabase publishable key in .env.example (resolves #45)

### DIFF
--- a/src/application/.env.example
+++ b/src/application/.env.example
@@ -1,7 +1,7 @@
 # Update these with your Supabase details from your Project Settings > API Keys
 # then rename this file from .env.example to .env.local
 NEXT_PUBLIC_SUPABASE_URL=https://kuopbajnxyxpzzgrkzcn.supabase.co
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_Nbj5PIhiuzhtaDVmBpNsZg_m5jI_7xq
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_WTqfKWPQygDYSx8L7UnT7Q_XaE900Hi
 
 # DO NOT share this key publicly! It should only be in your .env.local
 SUPABASE_SERVICE_ROLE_KEY=YOUR_SUPABASE_SECRET_API_KEY


### PR DESCRIPTION
### Description
This PR updates the placeholder publishable key in `.env.example` with the new rotated key. This ensures that any new environment setup using the example as a template will use the active connection credentials.

### Changes
- Updated `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` in `src/application/.env.example`.

Resolves #45.