### PR TITLE
feat: Add image field to package table in DB script

### DIFF
--- a/src/database/database-script.sql
+++ b/src/database/database-script.sql
@@ -127,7 +127,8 @@ CREATE TABLE package (
     package_name TEXT NOT NULL,
     package_price NUMERIC(10, 2) NOT NULL,
     campaign_start_dateTime TIMESTAMPTZ,
-    campaign_end_dateTime TIMESTAMPTZ
+    campaign_end_dateTime TIMESTAMPTZ,
+    image_src TEXT        -- URL to the package image
 );
 
 CREATE TABLE package_detail (


### PR DESCRIPTION
Closes #55. 

Added the `image_src` field to the `package` table in `src/database/database-script.sql` to allow each package to have its own image, consistent with the `massage` table.

- Field name: `image_src`
- Data type: `TEXT`
- Comment: `-- URL to the package image`