### PR TITLE
feat: Add collect deadline field to coupon table in DB script

### DIFF
--- a/src/database/database-script.sql
+++ b/src/database/database-script.sql
@@ -119,7 +119,8 @@ CREATE TABLE coupon (
     coupon_id SERIAL PRIMARY KEY,
     coupon_name TEXT NOT NULL,
     discount_percent NUMERIC(5, 2) NOT NULL,
-    description TEXT
+    description TEXT,
+    collect_deadline TIMESTAMPTZ -- Last day the coupon can be collected
 );
 
 CREATE TABLE package (


### PR DESCRIPTION
Closes #58.

Added the `collect_deadline` field to the `coupon` table in `src/database/database-script.sql`.

- Field name: `collect_deadline`
- Type: `TIMESTAMPTZ`
- Description: Stores the last day that each coupon can be collected.