### PR TITLE
refactor: modularize coupon page with tabs and extract UI components

### DIFF
--- a/src/application/app/coupon/page.tsx
+++ b/src/application/app/coupon/page.tsx
@@ -3,281 +3,302 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
-import { Loader2, TicketPercent, CheckCircle2, AlertCircle } from "lucide-react";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import {
+  Loader2,
+  CheckCircle2,
+  AlertCircle,
+  Ticket,
+  History,
+  PlusCircle,
+} from "lucide-react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { EmptyCouponState } from "@/components/coupon/empty-coupon-state";
+import { ActiveCouponCard } from "@/components/coupon/active-coupon-card";
+import { AvailableCouponCard } from "@/components/coupon/available-coupon-card";
+import { HistoryCouponList } from "@/components/coupon/history-coupon-list";
 
 export default function CouponPage() {
-    const router = useRouter();
-    const [isLoading, setIsLoading] = useState(true);
-    const [coupons, setCoupons] = useState<any[]>([]);
-    const [myCoupons, setMyCoupons] = useState<any[]>([]);
-    const [isClaiming, setIsClaiming] = useState<string | null>(null);
-    const [alertMessage, setAlertMessage] = useState<{ message: string, type: 'success' | 'error' } | null>(null);
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(true);
+  const [coupons, setCoupons] = useState<any[]>([]);
+  const [myCoupons, setMyCoupons] = useState<any[]>([]);
+  const [isClaiming, setIsClaiming] = useState<string | null>(null);
+  const [alertMessage, setAlertMessage] = useState<{
+    message: string;
+    type: "success" | "error";
+  } | null>(null);
 
-    const showAlert = (message: string, type: 'success' | 'error') => {
-        setAlertMessage({ message, type });
-        setTimeout(() => setAlertMessage(null), 3000);
-    };
+  const showAlert = (message: string, type: "success" | "error") => {
+    setAlertMessage({ message, type });
+    setTimeout(() => setAlertMessage(null), 3000);
+  };
 
-    useEffect(() => {
-        const checkUserAndFetchCoupons = async () => {
-            const supabase = createClient();
-            const { data: { session }, error } = await supabase.auth.getSession();
+  useEffect(() => {
+    const checkUserAndFetchCoupons = async () => {
+      const supabase = createClient();
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
 
-            if (error || !session) {
-                router.push("/sign-in");
-                return;
-            }
+      if (error || !session) {
+        router.push("/auth/login");
+        return;
+      }
 
-            try {
-                // Fetch customer ID
-                const customerRes = await fetch(`/api/customer?profile_id=${session.user.id}`);
-                const customerData = await customerRes.json();
+      try {
+        // Fetch customer ID
+        const customerRes = await fetch(
+          `/api/customer?profile_id=${session.user.id}`,
+        );
+        const customerData = await customerRes.json();
 
-                if (!customerData.success || !customerData.data) {
-                    throw new Error("Could not fetch customer info");
-                }
-
-                const customer_id = Array.isArray(customerData.data)
-                    ? customerData.data[0]?.customer_id
-                    : customerData.data?.customer_id;
-
-                if (!customer_id) {
-                    throw new Error("Customer ID not found");
-                }
-
-                await fetchCoupons(customer_id);
-            } catch (err) {
-                console.error("Error fetching data:", err);
-            } finally {
-                setIsLoading(false);
-            }
-        };
-
-        checkUserAndFetchCoupons();
-    }, [router]);
-
-    const fetchCoupons = async (customer_id: number) => {
-        try {
-            const [availableRes, myRes] = await Promise.all([
-                fetch('/api/coupon'),
-                fetch(`/api/member_coupon?customer_id=${customer_id}`)
-            ]);
-
-            const availableData = await availableRes.json();
-            const myData = await myRes.json();
-
-            if (availableData.success) {
-                setCoupons(availableData.data || []);
-            }
-            if (myData.success) {
-                setMyCoupons(myData.data || []);
-            }
-        } catch (error) {
-            console.error("Error fetching coupons:", error);
+        if (!customerData.success || !customerData.data) {
+          throw new Error("Could not fetch customer info");
         }
-    };
 
-    const handleClaimCoupon = async (coupon_id: number) => {
-        setIsClaiming(coupon_id.toString());
-        try {
-            const supabase = createClient();
-            const { data: { session } } = await supabase.auth.getSession();
+        const customer_id = Array.isArray(customerData.data)
+          ? customerData.data[0]?.customer_id
+          : customerData.data?.customer_id;
 
-            if (!session) {
-                showAlert("Please sign in first", "error");
-                return;
-            }
-
-            const customerRes = await fetch(`/api/customer?profile_id=${session.user.id}`);
-            const customerData = await customerRes.json();
-            const customer_id = Array.isArray(customerData.data)
-                ? customerData.data[0]?.customer_id
-                : customerData.data?.customer_id;
-
-            if (!customer_id) {
-                showAlert("Customer record not found", "error");
-                return;
-            }
-
-            // check if already claimed
-            const alreadyClaimed = myCoupons.find(mc => mc.coupon_id === coupon_id);
-            if (alreadyClaimed) {
-                showAlert(alreadyClaimed.is_used ? "คุณเคยเก็บและใช้คูปองนี้แล้ว" : "คุณมีคูปองนี้แล้ว", "error");
-                setIsClaiming(null);
-                return;
-            }
-
-            const res = await fetch("/api/member_coupon", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    customer_id: customer_id,
-                    coupon_id: coupon_id,
-                    is_used: false,
-                    expire_dateTime: null
-                }),
-            });
-
-            const data = await res.json();
-            if (data.success) {
-                showAlert("เก็บคูปองสำเร็จแล้ว!", "success");
-                // Refresh list
-                await fetchCoupons(customer_id);
-            } else {
-                showAlert(data.error || "Failed to claim coupon", "error");
-            }
-        } catch (error) {
-            console.error(error);
-            showAlert("An error occurred while claiming", "error");
-        } finally {
-            setIsClaiming(null);
+        if (!customer_id) {
+          throw new Error("Customer ID not found");
         }
+
+        await fetchCoupons(customer_id);
+      } catch (err) {
+        console.error("Error fetching data:", err);
+      } finally {
+        setIsLoading(false);
+      }
     };
 
-    return (
-        <main className="min-h-screen bg-background font-mitr relative overflow-hidden">
-            {alertMessage && (
-                <div className={`fixed bottom-8 right-8 z-50 p-4 px-6 rounded-2xl shadow-xl border flex items-center gap-3 transition-all duration-300 animate-in slide-in-from-bottom-5 fade-in ${alertMessage.type === 'success' ? 'bg-[#f0fdf4] border-[#bbf7d0] text-[#166534]' : 'bg-[#fef2f2] border-[#fecaca] text-[#991b1b]'}`}>
-                    {alertMessage.type === 'success' ? <CheckCircle2 className="h-5 w-5" /> : <AlertCircle className="h-5 w-5" />}
-                    <p className="font-medium">{alertMessage.message}</p>
+    checkUserAndFetchCoupons();
+  }, [router]);
+
+  const fetchCoupons = async (customer_id: number) => {
+    try {
+      const [availableRes, myRes] = await Promise.all([
+        fetch("/api/coupon"),
+        fetch(`/api/member_coupon?customer_id=${customer_id}`),
+      ]);
+
+      const availableData = await availableRes.json();
+      const myData = await myRes.json();
+
+      if (availableData.success) {
+        setCoupons(availableData.data || []);
+      }
+      if (myData.success) {
+        setMyCoupons(myData.data || []);
+      }
+    } catch (error) {
+      console.error("Error fetching coupons:", error);
+    }
+  };
+
+  const handleClaimCoupon = async (coupon_id: number) => {
+    setIsClaiming(coupon_id.toString());
+    try {
+      const supabase = createClient();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (!session) {
+        showAlert("Please sign in first", "error");
+        return;
+      }
+
+      const customerRes = await fetch(
+        `/api/customer?profile_id=${session.user.id}`,
+      );
+      const customerData = await customerRes.json();
+      const customer_id = Array.isArray(customerData.data)
+        ? customerData.data[0]?.customer_id
+        : customerData.data?.customer_id;
+
+      if (!customer_id) {
+        showAlert("Customer record not found", "error");
+        return;
+      }
+
+      // check if already claimed
+      const alreadyClaimed = myCoupons.find((mc) => mc.coupon_id === coupon_id);
+      if (alreadyClaimed) {
+        showAlert(
+          alreadyClaimed.is_used
+            ? "คุณเคยเก็บและใช้คูปองนี้แล้ว"
+            : "คุณมีคูปองนี้แล้ว",
+          "error",
+        );
+        setIsClaiming(null);
+        return;
+      }
+
+      const res = await fetch("/api/member_coupon", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          customer_id: customer_id,
+          coupon_id: coupon_id,
+          is_used: false,
+          expire_dateTime: null,
+        }),
+      });
+
+      const data = await res.json();
+      if (data.success) {
+        showAlert("เก็บคูปองสำเร็จแล้ว!", "success");
+        // Refresh list
+        await fetchCoupons(customer_id);
+      } else {
+        showAlert(data.error || "Failed to claim coupon", "error");
+      }
+    } catch (error) {
+      console.error(error);
+      showAlert("An error occurred while claiming", "error");
+    } finally {
+      setIsClaiming(null);
+    }
+  };
+
+  const activeCoupons = myCoupons.filter((mc) => !mc.is_used);
+  const historyCoupons = myCoupons.filter((mc) => mc.is_used);
+
+  return (
+    <main className="min-h-screen bg-background font-mitr relative overflow-hidden">
+      {alertMessage && (
+        <div
+          className={`fixed bottom-8 right-8 z-50 p-4 px-6 rounded-2xl shadow-xl border flex items-center gap-3 transition-all duration-300 animate-in slide-in-from-bottom-5 fade-in ${alertMessage.type === "success" ? "bg-[#f0fdf4] border-[#bbf7d0] text-[#166534]" : "bg-[#fef2f2] border-[#fecaca] text-[#991b1b]"}`}
+        >
+          {alertMessage.type === "success" ? (
+            <CheckCircle2 className="h-5 w-5" />
+          ) : (
+            <AlertCircle className="h-5 w-5" />
+          )}
+          <p className="font-medium font-sans">{alertMessage.message}</p>
+        </div>
+      )}
+      <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] rounded-full bg-primary/5 blur-[100px] pointer-events-none" />
+      <div className="absolute top-[40%] right-[-10%] w-[30%] h-[50%] rounded-full bg-secondary/5 blur-[100px] pointer-events-none" />
+
+      {isLoading ? (
+        <div className="flex justify-center items-center py-20 min-h-[50vh]">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      ) : (
+        <div className="max-w-4xl mx-auto px-4 md:px-8 py-12 relative z-10 space-y-8">
+          <div className="flex flex-col items-center text-center mb-8 border-b border-border/50 pb-8">
+            <h1 className="text-3xl md:text-4xl font-medium tracking-tight text-foreground mb-3">
+              คูปองส่วนลด
+            </h1>
+            <p className="text-muted-foreground font-sans max-w-lg">
+              จัดการคูปองของคุณ
+              หรือเก็บคูปองใหม่เพื่อใช้เป็นส่วนลดในการจองบริการ
+            </p>
+          </div>
+
+          <Tabs defaultValue="my-coupons" className="w-full">
+            <TabsList className="grid w-full grid-cols-3 mb-8 h-12 rounded-xl bg-muted/40 p-1 font-sans">
+              <TabsTrigger
+                value="my-coupons"
+                className="rounded-lg data-[state=active]:bg-background data-[state=active]:shadow-sm transition-all gap-2 h-full"
+              >
+                <Ticket className="h-4 w-4" />
+                คูปองของฉัน
+                {activeCoupons.length > 0 && (
+                  <span className="ml-1 bg-primary/10 text-primary text-[10px] px-1.5 py-0.5 rounded-full font-semibold">
+                    {activeCoupons.length}
+                  </span>
+                )}
+              </TabsTrigger>
+              <TabsTrigger
+                value="discover"
+                className="rounded-lg data-[state=active]:bg-background data-[state=active]:shadow-sm transition-all gap-2 h-full"
+              >
+                <PlusCircle className="h-4 w-4" />
+                เก็บเพิ่ม
+              </TabsTrigger>
+              <TabsTrigger
+                value="history"
+                className="rounded-lg data-[state=active]:bg-background data-[state=active]:shadow-sm transition-all gap-2 h-full"
+              >
+                <History className="h-4 w-4" />
+                ประวัติการใช้
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent
+              value="my-coupons"
+              className="mt-0 focus-visible:outline-none focus-visible:ring-0"
+            >
+              {activeCoupons.length === 0 ? (
+                <EmptyCouponState
+                  icon={<Ticket className="h-12 w-12" />}
+                  message="คุณยังไม่มีคูปองที่พร้อมใช้งานในขณะนี้"
+                />
+              ) : (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {activeCoupons.map(
+                    (mc, index) =>
+                      mc.coupon && (
+                        <ActiveCouponCard
+                          key={`active-${mc.member_coupon_id}-${index}`}
+                          coupon={mc.coupon}
+                        />
+                      ),
+                  )}
                 </div>
-            )}
-            <div className="absolute top-[-10%] left-[-10%] w-[40%] h-[40%] rounded-full bg-primary/5 blur-[100px] pointer-events-none" />
-            <div className="absolute top-[40%] right-[-10%] w-[30%] h-[50%] rounded-full bg-secondary/5 blur-[100px] pointer-events-none" />
+              )}
+            </TabsContent>
 
-            {isLoading ? (
-                <div className="flex justify-center items-center py-20 min-h-[50vh]">
-                    <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            <TabsContent
+              value="discover"
+              className="mt-0 focus-visible:outline-none focus-visible:ring-0"
+            >
+              {coupons.length === 0 ? (
+                <EmptyCouponState
+                  icon={<PlusCircle className="h-12 w-12" />}
+                  message="ไม่มีคูปองใหม่ที่สามารถเก็บได้ในขณะนี้"
+                />
+              ) : (
+                <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                  {coupons.map((coupon, index) => {
+                    const claimedRecord = myCoupons.find(
+                      (mc) => mc.coupon_id === coupon.coupon_id,
+                    );
+                    return (
+                      <AvailableCouponCard
+                        key={`avail-${coupon.coupon_id}-${index}`}
+                        coupon={coupon}
+                        isClaimed={!!claimedRecord}
+                        isUsed={!!claimedRecord?.is_used}
+                        isClaiming={isClaiming === coupon.coupon_id.toString()}
+                        onClaim={handleClaimCoupon}
+                      />
+                    );
+                  })}
                 </div>
-            ) : (
-                <div className="max-w-6xl mx-auto px-6 py-12 relative z-10 space-y-16">
+              )}
+            </TabsContent>
 
-                    <div className="flex flex-col items-center text-center mb-12 border-b border-border/50 pb-8">
-                        <h1 className="text-4xl md:text-5xl font-bold tracking-tight text-foreground mb-4">
-                            คูปองส่วนลด
-                        </h1>
-                        <p className="text-lg text-muted-foreground max-w-2xl font-light">
-                            เก็บคูปองส่วนลดพิเศษเพื่อใช้เป็นส่วนลดในการจองบริการนวดของคุณ
-                        </p>
-                    </div>
-
-                    <section>
-                        <div className="flex items-center gap-3 mb-8">
-                            <h2 className="text-2xl font-bold text-foreground">คูปองของฉัน</h2>
-                            <Badge variant="secondary" className="bg-primary/10 text-primary border-0 rounded-full px-3">{myCoupons.length} รายการ</Badge>
-                        </div>
-
-                        {myCoupons.length === 0 ? (
-                            <div className="bg-muted/30 border border-border/50 rounded-3xl p-12 text-center flex flex-col items-center justify-center min-h-[300px]">
-                                <AlertCircle className="h-12 w-12 text-muted-foreground mb-4 opacity-50" />
-                                <p className="text-lg text-muted-foreground">คุณยังไม่มีคูปองส่วนลด</p>
-                            </div>
-                        ) : (
-                            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-                                {myCoupons.map((mc, index) => {
-                                    const coupon = mc.coupon;
-                                    if (!coupon) return null;
-
-                                    return (
-                                        <Card key={`my-${mc.member_coupon_id}-${index}`} className={`border-primary/20 backdrop-blur-sm overflow-hidden relative flex flex-col transition-all hover:shadow-md ${mc.is_used ? 'bg-muted/30 opacity-70 grayscale' : 'bg-background/80'}`}>
-                                            <div className="absolute top-4 right-4 z-10">
-                                                {mc.is_used ? (
-                                                    <Badge variant="secondary" className="text-xs">ใช้แล้ว</Badge>
-                                                ) : (
-                                                    <Badge variant="default" className="text-xs bg-primary/10 text-primary border-0 shadow-none">พร้อมใช้</Badge>
-                                                )}
-                                            </div>
-
-                                            <CardContent className="p-0 flex items-center h-[120px]">
-                                                <div className="w-1/3 bg-primary/5 flex flex-col items-center justify-center h-full relative">
-                                                    <span className="text-2xl font-bold tracking-tighter text-primary">
-                                                        {coupon.discount_percent}%
-                                                    </span>
-                                                    <div className="absolute -right-[1px] top-0 bottom-0 w-[2px] border-r-2 border-dashed border-border/70 z-10" />
-                                                </div>
-                                                <div className="w-2/3 p-5 flex flex-col justify-center">
-                                                    <h3 className="font-semibold text-base line-clamp-1 mb-1">{coupon.coupon_name}</h3>
-                                                    <p className="text-xs text-muted-foreground line-clamp-2">
-                                                        {coupon.description || "ใช้เป็นส่วนลดในการจองบริการ"}
-                                                    </p>
-                                                </div>
-                                            </CardContent>
-                                        </Card>
-                                    );
-                                })}
-                            </div>
-                        )}
-                    </section>
-
-                    <section className="pt-8 border-t border-border/40">
-                        <div className="flex items-center gap-3 mb-8">
-                            <h2 className="text-2xl font-bold text-foreground">คูปองทั้งหมดที่สามารถเก็บได้</h2>
-                            <Badge variant="secondary" className="bg-primary/10 text-primary border-0 rounded-full px-3">{coupons.length} รายการ</Badge>
-                        </div>
-
-                        {coupons.length === 0 ? (
-                            <div className="bg-muted/30 border border-border/50 rounded-3xl p-12 text-center flex flex-col items-center justify-center min-h-[300px]">
-                                <TicketPercent className="h-12 w-12 text-muted-foreground mb-4 opacity-50" />
-                                <p className="text-lg text-muted-foreground">ไม่มีคูปองที่สามารถเก็บได้ในขณะนี้</p>
-                            </div>
-                        ) : (
-                            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-                                {coupons.map((coupon, index) => {
-                                    const claimedRecord = myCoupons.find(mc => mc.coupon_id === coupon.coupon_id);
-                                    const isClaimed = !!claimedRecord;
-                                    const isUsed = claimedRecord?.is_used;
-
-                                    return (
-                                        <Card key={`avail-${coupon.coupon_id}-${index}`} className="border-primary/20 bg-background/50 backdrop-blur-sm overflow-hidden flex flex-col transition-all hover:shadow-md hover:border-primary/40 group">
-                                            <div className="flex aspect-[3/1] bg-primary/5 border-b border-primary/10 relative overflow-hidden items-center justify-center">
-                                                <div className="absolute -left-4 w-8 h-8 rounded-full bg-background border-r border-primary/10"></div>
-                                                <div className="absolute -right-4 w-8 h-8 rounded-full bg-background border-l border-primary/10"></div>
-                                                <TicketPercent className="h-12 w-12 text-primary/40 group-hover:scale-110 transition-transform duration-500" />
-                                                <div className="absolute inset-0 flex flex-col items-center justify-center">
-                                                    <span className="text-3xl font-bold tracking-tighter text-primary">
-                                                        {coupon.discount_percent}%
-                                                    </span>
-                                                    <span className="text-xs font-medium uppercase tracking-widest text-primary/70">ส่วนลด</span>
-                                                </div>
-                                            </div>
-                                            <CardHeader className="pt-6">
-                                                <CardTitle className="text-xl font-medium line-clamp-1">{coupon.coupon_name}</CardTitle>
-                                                <CardDescription className="line-clamp-2 min-h-[40px] mt-2">
-                                                    {coupon.description || "ใช้เป็นส่วนลดในการจองบริการ"}
-                                                </CardDescription>
-                                            </CardHeader>
-                                            <CardFooter className="pt-2 pb-6 mt-auto">
-                                                <Button
-                                                    className={`w-full gap-2 relative overflow-hidden transition-all ${isClaimed ? 'bg-muted text-muted-foreground hover:bg-muted text-xs' : 'group/btn'}`}
-                                                    disabled={isClaimed || isClaiming === coupon.coupon_id.toString()}
-                                                    onClick={() => handleClaimCoupon(coupon.coupon_id)}
-                                                    variant={isClaimed ? "secondary" : "default"}
-                                                >
-                                                    {isClaiming === coupon.coupon_id.toString() ? (
-                                                        <Loader2 className="h-4 w-4 animate-spin" />
-                                                    ) : isClaimed ? (
-                                                        <>
-                                                            <CheckCircle2 className="h-4 w-4 flex-shrink-0" />
-                                                            <span className="truncate">
-                                                                {isUsed ? 'คุณเคยเก็บและใช้คูปองนี้แล้ว' : 'คุณมีคูปองนี้แล้ว'}
-                                                            </span>
-                                                        </>
-                                                    ) : (
-                                                        "เก็บคูปอง"
-                                                    )}
-                                                </Button>
-                                            </CardFooter>
-                                        </Card>
-                                    );
-                                })}
-                            </div>
-                        )}
-                    </section>
-                </div>
-            )}
-        </main>
-    );
+            <TabsContent
+              value="history"
+              className="mt-0 focus-visible:outline-none focus-visible:ring-0"
+            >
+              {historyCoupons.length === 0 ? (
+                <EmptyCouponState
+                  icon={<History className="h-12 w-12" />}
+                  message="คุณยังไม่มีประวัติการใช้คูปอง"
+                />
+              ) : (
+                <HistoryCouponList coupons={historyCoupons} />
+              )}
+            </TabsContent>
+          </Tabs>
+        </div>
+      )}
+    </main>
+  );
 }

--- a/src/application/components/coupon/active-coupon-card.tsx
+++ b/src/application/components/coupon/active-coupon-card.tsx
@@ -1,0 +1,38 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+interface ActiveCouponCardProps {
+  coupon: {
+    coupon_id: number;
+    coupon_name: string;
+    discount_percent: number;
+    description: string;
+  };
+}
+
+export function ActiveCouponCard({ coupon }: ActiveCouponCardProps) {
+  return (
+    <Card className="border-primary/20 bg-background/80 backdrop-blur-sm overflow-hidden relative flex flex-col transition-all hover:shadow-md">
+      <div className="absolute top-4 right-4 z-10">
+        <Badge variant="default" className="text-xs bg-primary/10 text-primary border-0 shadow-none">
+          พร้อมใช้
+        </Badge>
+      </div>
+
+      <CardContent className="p-0 flex items-center h-[120px]">
+        <div className="w-1/3 bg-primary/5 flex flex-col items-center justify-center h-full relative">
+          <span className="text-2xl font-bold tracking-tighter text-primary">
+            {coupon.discount_percent}%
+          </span>
+          <div className="absolute -right-[1px] top-0 bottom-0 w-[2px] border-r-2 border-dashed border-border/70 z-10" />
+        </div>
+        <div className="w-2/3 p-5 flex flex-col justify-center">
+          <h3 className="font-semibold text-base line-clamp-1 mb-1">{coupon.coupon_name}</h3>
+          <p className="text-xs text-muted-foreground line-clamp-2">
+            {coupon.description || "ใช้เป็นส่วนลดในการจองบริการ"}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/application/components/coupon/available-coupon-card.tsx
+++ b/src/application/components/coupon/available-coupon-card.tsx
@@ -1,0 +1,61 @@
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { TicketPercent, CheckCircle2, Loader2 } from "lucide-react";
+
+interface AvailableCouponCardProps {
+  coupon: {
+    coupon_id: number;
+    coupon_name: string;
+    discount_percent: number;
+    description: string;
+  };
+  isClaimed: boolean;
+  isUsed: boolean;
+  isClaiming: boolean;
+  onClaim: (couponId: number) => void;
+}
+
+export function AvailableCouponCard({ coupon, isClaimed, isUsed, isClaiming, onClaim }: AvailableCouponCardProps) {
+  return (
+    <Card className="border-primary/20 bg-background/50 backdrop-blur-sm overflow-hidden flex flex-col transition-all hover:shadow-md hover:border-primary/40 group">
+      <div className="flex aspect-[3/1] bg-primary/5 border-b border-primary/10 relative overflow-hidden items-center justify-center">
+        <div className="absolute -left-4 w-8 h-8 rounded-full bg-background border-r border-primary/10"></div>
+        <div className="absolute -right-4 w-8 h-8 rounded-full bg-background border-l border-primary/10"></div>
+        <TicketPercent className="h-12 w-12 text-primary/40 group-hover:scale-110 transition-transform duration-500" />
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-3xl font-bold tracking-tighter text-primary">
+            {coupon.discount_percent}%
+          </span>
+          <span className="text-xs font-medium uppercase tracking-widest text-primary/70">ส่วนลด</span>
+        </div>
+      </div>
+      <CardHeader className="pt-6">
+        <CardTitle className="text-xl font-medium line-clamp-1">{coupon.coupon_name}</CardTitle>
+        <CardDescription className="line-clamp-2 min-h-[40px] mt-2">
+          {coupon.description || "ใช้เป็นส่วนลดในการจองบริการ"}
+        </CardDescription>
+      </CardHeader>
+      <CardFooter className="pt-2 pb-6 mt-auto">
+        <Button
+          className={`w-full gap-2 relative overflow-hidden transition-all ${isClaimed ? 'bg-muted text-muted-foreground hover:bg-muted text-xs' : 'group/btn'}`}
+          disabled={isClaimed || isClaiming}
+          onClick={() => onClaim(coupon.coupon_id)}
+          variant={isClaimed ? "secondary" : "default"}
+        >
+          {isClaiming ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : isClaimed ? (
+            <>
+              <CheckCircle2 className="h-4 w-4 flex-shrink-0" />
+              <span className="truncate">
+                {isUsed ? 'คุณเคยเก็บและใช้คูปองนี้แล้ว' : 'คุณมีคูปองนี้แล้ว'}
+              </span>
+            </>
+          ) : (
+            "เก็บคูปอง"
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/application/components/coupon/empty-coupon-state.tsx
+++ b/src/application/components/coupon/empty-coupon-state.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from "react";
+
+interface EmptyCouponStateProps {
+  icon: ReactNode;
+  message: string;
+}
+
+export function EmptyCouponState({ icon, message }: EmptyCouponStateProps) {
+  return (
+    <div className="bg-muted/30 border border-border/50 rounded-3xl p-12 text-center flex flex-col items-center justify-center min-h-[300px]">
+      <div className="text-muted-foreground mb-4 opacity-50 flex items-center justify-center">
+        {icon}
+      </div>
+      <p className="text-lg text-muted-foreground">{message}</p>
+    </div>
+  );
+}

--- a/src/application/components/coupon/history-coupon-list.tsx
+++ b/src/application/components/coupon/history-coupon-list.tsx
@@ -1,0 +1,44 @@
+import { Badge } from "@/components/ui/badge";
+
+interface HistoryCouponListProps {
+  coupons: any[];
+}
+
+export function HistoryCouponList({ coupons }: HistoryCouponListProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      {coupons.map((mc, index) => {
+        const coupon = mc.coupon;
+        if (!coupon) return null;
+
+        return (
+          <div
+            key={`history-${mc.member_coupon_id}-${index}`}
+            className="flex items-center justify-between p-4 rounded-2xl border border-border/40 bg-muted/20 opacity-80 grayscale transition-all hover:opacity-100 hover:grayscale-0"
+          >
+            <div className="flex items-center gap-4">
+              <div className="h-12 w-12 rounded-xl bg-primary/10 flex flex-col items-center justify-center shrink-0 border border-primary/10">
+                <span className="text-sm font-bold text-primary">{coupon.discount_percent}%</span>
+              </div>
+              <div className="flex flex-col">
+                <span className="font-medium text-sm text-foreground">{coupon.coupon_name}</span>
+                <span className="text-xs text-muted-foreground">{coupon.description || "ใช้เป็นส่วนลดในการจองบริการ"}</span>
+              </div>
+            </div>
+
+            <div className="flex flex-col items-end gap-1 shrink-0">
+              <Badge variant="secondary" className="text-[10px] font-normal px-2 py-0 h-5">
+                ใช้แล้ว
+              </Badge>
+              {mc.booking_id && (
+                <span className="text-[10px] text-muted-foreground">
+                  จอง: #{mc.booking_id}
+                </span>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/application/components/ui/tabs.tsx
+++ b/src/application/components/ui/tabs.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/src/application/package-lock.json
+++ b/src/application/package-lock.json
@@ -168,7 +168,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -574,7 +573,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -615,7 +613,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -643,7 +640,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -4420,7 +4416,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.97.0.tgz",
       "integrity": "sha512-kTD91rZNO4LvRUHv4x3/4hNmsEd2ofkYhuba2VMUPRVef1RCmnHtm7rIws38Fg0yQnOSZOplQzafn0GSiy6GVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.97.0",
         "@supabase/functions-js": "2.97.0",
@@ -4468,6 +4463,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4557,7 +4553,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4664,7 +4661,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4675,7 +4671,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4734,7 +4729,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -5366,7 +5360,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5417,6 +5410,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5840,7 +5834,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6331,6 +6324,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6383,7 +6377,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6411,8 +6406,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -6711,7 +6705,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6885,7 +6878,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8217,7 +8209,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8248,7 +8239,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -8472,6 +8462,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9113,7 +9104,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9273,6 +9263,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9288,6 +9279,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9300,7 +9292,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -9565,7 +9558,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9596,7 +9588,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10646,7 +10637,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10859,7 +10849,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11044,7 +11033,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11138,7 +11126,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
This PR refactors the coupon page to follow a component-driven design approach and improves the UI/UX for long-term users with extensive coupon histories.

**Key Changes:**
- **Tabbed Interface:** Introduced Shadcn UI `<Tabs>` to logically separate coupons into "คูปองของฉัน" (My Coupons), "เก็บเพิ่ม" (Discover), and "ประวัติการใช้" (History).
- **Component Extraction:** Split the massive inline HTML from `page.tsx` into reusable, isolated components within `src/application/components/coupon/`:
  - `active-coupon-card.tsx`
  - `available-coupon-card.tsx`
  - `history-coupon-list.tsx`
  - `empty-coupon-state.tsx`
- **Dense History View:** Used coupons are now displayed in a space-saving horizontal list rather than taking up full-size cards.
- **Improved Maintainability:** Adheres closely to the design system guidelines outlined in `generative-readhere.md`.