### PR TITLE
fix: Store booking creation time instead of appointment time in booking_dateTime

### DIFF
--- a/src/application/app/api/booking/route.ts
+++ b/src/application/app/api/booking/route.ts
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest) {
       customer_name: body.customer_name,
       customer_phone: body.customer_phone,
       customer_email: body.customer_email || null,
-      booking_dateTime: body.booking_datetime,
+      booking_dateTime: new Date().toISOString(),
       total_price: body.total_price || 0,
       payment_status: "pending", // Waiting for manager to verify deposit slip
     };


### PR DESCRIPTION
## Summary

Fixes the `booking_dateTime` field to store **when the booking was created** rather than the appointment start time. Previously, `booking_dateTime` was redundantly storing the same value as the first service's `massage_start_dateTime`.

Closes #95

---

## Changes

### Before
```typescript
booking_dateTime: body.booking_datetime,  // Appointment start time (redundant)
```

### After
```typescript
booking_dateTime: new Date().toISOString(),  // Booking creation timestamp
```

---

## Impact

### Database Records
| Field | Previous Behavior | New Behavior |
|-------|-------------------|--------------|
| `booking.booking_dateTime` | Appointment start time (e.g., "2026-03-30T14:00:00") | Booking creation time (e.g., "2026-03-28T10:30:00") |
| `booking_detail.massage_start_dateTime` | Appointment start time (same as above) | Appointment start time (unchanged) |

### Benefits
- **Analytics**: Track when customers typically make bookings
- **Business insights**: Measure lead time between booking creation and appointment
- **Audit trail**: Know exactly when each booking was submitted
- **Data accuracy**: Eliminates redundancy between `booking` and `booking_detail` tables

---

## Testing

### Manual Testing Checklist
- [x] Create a new booking with appointment date in the future
- [x] Verify `booking.booking_dateTime` is set to current timestamp
- [x] Verify `booking_detail.massage_start_dateTime` matches selected appointment time
- [x] Confirm booking confirmation page displays correct appointment time
- [x] Test with multiple services (ensure all service times are still correct)
- [x] Test with package services (ensure times are calculated correctly)

### Expected Results
```sql
-- Example booking created on March 28 at 10:30 AM for appointment on March 30 at 2:00 PM
SELECT 
  booking_dateTime,                      -- 2026-03-28T10:30:00+07:00 (NOW)
  (SELECT massage_start_dateTime 
   FROM booking_detail 
   WHERE booking_id = b.booking_id 
   LIMIT 1) as first_service_time        -- 2026-03-30T14:00:00+07:00 (Selected time)
FROM booking b
WHERE booking_id = [new_booking_id];
```

---

## Files Changed

| File | Lines Changed | Description |
|------|---------------|-------------|
| `src/application/app/api/booking/route.ts` | 1 | Changed `booking_dateTime` from `body.booking_datetime` to `new Date().toISOString()` |

---

## Notes

- **Existing data**: No migration needed. Existing 6 bookings retain their current `booking_dateTime` values (cannot recover original creation time)
- **Frontend**: No changes required. The `booking_datetime` field in the request payload is still used to calculate service start times
- **Database schema**: No schema changes. Column name remains `booking_dateTime` per design documentation