### PR TITLE
feat: Add employee (therapist) profile image field to database

### DIFF
--- a/src/database/database-script.sql
+++ b/src/database/database-script.sql
@@ -62,6 +62,7 @@ CREATE TABLE employee (
     last_name TEXT NOT NULL,
     phone_number TEXT,
     work_since DATE,
+    image_src TEXT,
     profile_id UUID REFERENCES profiles(profile_id) ON DELETE SET NULL
 );
 


### PR DESCRIPTION
## Summary
Adds support for storing employee (therapist) profile pictures by introducing an `image_src` column to the `employee` table.

## Changes
- **Database**: Added `image_src TEXT` column to `employee` table in schema
- **Migration**: Applied Supabase migration `add_employee_image_src` (version 20260329075733)
- **API**: No code changes needed - existing GET/POST/PUT endpoints automatically support the new field through flexible Supabase client

## Implementation Details
The new column follows the existing pattern used in:
- `massage` table (stores massage image URLs)
- `package` table (stores package image URLs)

The field is:
- Optional/nullable (allows existing employees without images)
- Text type (stores URLs for external image storage or Supabase Storage paths)
- Updatable (can be added/modified for any employee)

## Testing
- ✅ Schema verified in Supabase database
- ✅ Migration applied successfully
- ✅ API routes compatible (no code changes required)
- ✅ Field is accessible via GET, POST, and PUT endpoints

## Closes
Closes #111

## Future Enhancements
- Frontend UI to display therapist photos in booking flow
- Image upload functionality (Supabase Storage integration)
- Profile management page to add/update therapist images